### PR TITLE
fix license 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "@taiheiko/weighted_pick",
-  "version": "1.0.0",
+  "name": "weighted-pick",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@taiheiko/weighted_pick",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "weighted-pick",
+      "version": "1.0.2",
+      "license": "MIT",
       "devDependencies": {
         "eslint": "^8.56.0",
         "eslint-config-standard": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "author": "Taisia Heiko",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com:taiheiko/weighted-pick.git"


### PR DESCRIPTION
Made the "license" property in `package.json` be consistent with `LICENSE`