### PR TITLE
Fix ES-Linter

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   env: {
     browser: true,
-    commonjs: true,
+    commonjs: false,
     es2021: true,
     jest: true
   },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test
+      - run: npm run lint


### PR DESCRIPTION
- Fixed ES-Linter configuration issue caused the switch from `commonjs` to `module` project type.
- Added linter run to the test github workflow.

Test plan:
```
% npm run lint
```