### PR TITLE
Check for NaN weights

### DIFF
--- a/__tests__/WeightedPick.test.js
+++ b/__tests__/WeightedPick.test.js
@@ -76,6 +76,12 @@ describe('WeightedPick', () => {
     expect(values).toHaveLength(n); // sanity check
     console.table(Object.fromEntries(histogram(values)));
   });
+
+  test('fails on NaN weight', () => {
+    expect(() => new WeightedPick([
+      new WeightedValue(2, NaN)
+    ])).toThrowError(/NaN weight is not allowed/);
+  });
 });
 
 function histogram (values) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,12 @@ export class WeightedPick {
         this.#weights = weights;
 
         // [[start1, end1), [start2, end2), ...]
-        const totalWeight = weights.reduce((acc, w) => acc + w.weight, 0);
+        const totalWeight = weights.reduce((acc, w) => {
+            if (isNaN(w.weight)) {
+                throw new Error('NaN weight is not allowed');
+            }
+            return acc + w.weight;
+        }, 0);
 
         this.#ranges = [];
         let runningSum = 0;


### PR DESCRIPTION
Disallowed NaN weights

Test plan
```
% npm run test
...
 ✓ __tests__/WeightedPick.test.js (6 tests) 4ms
   ✓ WeightedPick > 2 values, 50%/50%, 1K times 2ms
   ✓ WeightedPick > 2 values, 33%/66%, 1K times 0ms
   ✓ WeightedPick > 5 values, 20%/20%/20%/20%/20%, 1K times 0ms
   ✓ WeightedPick > 5 values, 10%/10%/30%/25%/25%, 1K times 0ms
   ✓ WeightedPick > prod values, 1K times 0ms
   ✓ WeightedPick > fails on NaN weight 0ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```