### PR TITLE
Check for nullable and empty weights

### DIFF
--- a/__tests__/WeightedPick.test.js
+++ b/__tests__/WeightedPick.test.js
@@ -83,7 +83,14 @@ describe('WeightedPick', () => {
     ])).toThrowError(/NaN weight is not allowed/);
   });
 
-  test('fails on nullable weights', () => {
+  test.each([
+    [null],
+    [undefined],
+    ['a string'],
+    [-1],
+    [{}],
+    [true]
+  ])('fails on non-array weights: %s', () => {
     expect(() => new WeightedPick(null)).toThrowError(/Weights is not an array/);
   });
 

--- a/__tests__/WeightedPick.test.js
+++ b/__tests__/WeightedPick.test.js
@@ -82,6 +82,14 @@ describe('WeightedPick', () => {
       new WeightedValue(2, NaN)
     ])).toThrowError(/NaN weight is not allowed/);
   });
+
+  test('fails on nullable weights', () => {
+    expect(() => new WeightedPick(null)).toThrowError(/Weights is not an array/);
+  });
+
+  test('fails on empty weights', () => {
+    expect(() => new WeightedPick([])).toThrowError(/Weights is empty/);
+  });
 });
 
 function histogram (values) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,13 @@ export class WeightedPick {
     #ranges;
 
     constructor(weights) {
-        // TODO: Check for empty input data.
+        if (!Array.isArray(weights)) {
+            throw new Error('Weights is not an array');
+        }
+        if (weights.length === 0) {
+            throw new Error('Weights is empty');
+        }
+
         this.#weights = weights;
 
         // [[start1, end1), [start2, end2), ...]


### PR DESCRIPTION
Disallowed nullable and empty weights

Test plan
```shell
% npm run test
...
 ✓ __tests__/WeightedPick.test.js (8 tests) 6ms
   ✓ WeightedPick > 2 values, 50%/50%, 1K times 3ms
   ✓ WeightedPick > 2 values, 33%/66%, 1K times 1ms
   ✓ WeightedPick > 5 values, 20%/20%/20%/20%/20%, 1K times 0ms
   ✓ WeightedPick > 5 values, 10%/10%/30%/25%/25%, 1K times 0ms
   ✓ WeightedPick > prod values, 1K times 0ms
   ✓ WeightedPick > fails on NaN weight 0ms
   ✓ WeightedPick > fails on nullable weights 0ms
   ✓ WeightedPick > fails on empty weights 0ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```