### PR TITLE
Fix 'fails on non-array weights' tests

### DIFF
--- a/__tests__/WeightedPick.test.js
+++ b/__tests__/WeightedPick.test.js
@@ -90,8 +90,8 @@ describe('WeightedPick', () => {
     [-1],
     [{}],
     [true],
-  ])('fails on non-array weights: %s', () => {
-    expect(() => new WeightedPick(null)).toThrowError(/Weights is not an array/);
+  ])('fails on non-array weights: %s', (weight) => {
+    expect(() => new WeightedPick(weight)).toThrowError(/Weights is not an array/);
   });
 
   test('fails on empty weights', () => {


### PR DESCRIPTION
Passes the parameter to the constructor in the test case

Test plan
```shell
% npm test run
...
 ✓ __tests__/WeightedPick.test.js (13 tests) 6ms
   ✓ WeightedPick > 2 values, 50%/50%, 1K times 2ms
   ✓ WeightedPick > 2 values, 33%/66%, 1K times 0ms
   ✓ WeightedPick > 5 values, 20%/20%/20%/20%/20%, 1K times 0ms
   ✓ WeightedPick > 5 values, 10%/10%/30%/25%/25%, 1K times 0ms
   ✓ WeightedPick > prod values, 1K times 1ms
   ✓ WeightedPick > fails on NaN weight 1ms
   ✓ WeightedPick > fails on non-array weights: null 0ms
   ✓ WeightedPick > fails on non-array weights: undefined 0ms
   ✓ WeightedPick > fails on non-array weights: a string 0ms
   ✓ WeightedPick > fails on non-array weights: -1 0ms
   ✓ WeightedPick > fails on non-array weights: {} 0ms
   ✓ WeightedPick > fails on non-array weights: true 0ms
   ✓ WeightedPick > fails on empty weights 0ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```