### PR TITLE
Check for negative and zero weights

### DIFF
--- a/__tests__/WeightedPick.test.js
+++ b/__tests__/WeightedPick.test.js
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { WeightedValue, WeightedPick } from '..';
 
 describe('WeightedPick', () => {
@@ -96,6 +97,16 @@ describe('WeightedPick', () => {
 
   test('fails on empty weights', () => {
     expect(() => new WeightedPick([])).toThrowError(/Weights is empty/);
+  });
+
+  test.each([
+    [-1],
+    [-0.5],
+    [0],
+  ])('fails on negative or zero weights: %d', (weight) => {
+    expect(() => new WeightedPick([
+      new WeightedValue(1, weight),
+    ])).toThrowError(/Negative or zero weight is not allowed: .*/);
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ export class WeightedPick {
             if (isNaN(w.weight)) {
                 throw new Error('NaN weight is not allowed');
             }
+            if (w.weight <= 0) {
+                throw new Error(`Negative or zero weight is not allowed: ${w.weight}`);
+            }
             return acc + w.weight;
         }, 0);
 


### PR DESCRIPTION
Disallowed negative and zero weights

Test plan
```shell
% npm run test
...
✓ __tests__/WeightedPick.test.js (16 tests) 5ms
   ✓ WeightedPick > 2 values, 50%/50%, 1K times 2ms
   ✓ WeightedPick > 2 values, 33%/66%, 1K times 0ms
   ✓ WeightedPick > 5 values, 20%/20%/20%/20%/20%, 1K times 0ms
   ✓ WeightedPick > 5 values, 10%/10%/30%/25%/25%, 1K times 0ms
   ✓ WeightedPick > prod values, 1K times 0ms
   ✓ WeightedPick > fails on NaN weight 0ms
   ✓ WeightedPick > fails on non-array weights: null 0ms
   ✓ WeightedPick > fails on non-array weights: undefined 0ms
   ✓ WeightedPick > fails on non-array weights: a string 0ms
   ✓ WeightedPick > fails on non-array weights: -1 0ms
   ✓ WeightedPick > fails on non-array weights: {} 0ms
   ✓ WeightedPick > fails on non-array weights: true 0ms
   ✓ WeightedPick > fails on empty weights 0ms
   ✓ WeightedPick > fails on negative or zero weights: -1 0ms
   ✓ WeightedPick > fails on negative or zero weights: -0.5 0ms
   ✓ WeightedPick > fails on negative or zero weights: 0 0ms

 Test Files  1 passed (1)
      Tests  16 passed (16)
```